### PR TITLE
Nctl upgr fixes

### DIFF
--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -34,14 +34,13 @@ function _main()
     _step_02
 
     # Set initial protocol version for use later.
-    N1_PROTOCOL_VERSION=$(get_node_protocol_version 1)
-
+    INITIAL_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     _step_03
     _step_04
     _step_05 "$STAGE_ID"
-    _step_06 "$N1_PROTOCOL_VERSION"
+    _step_06 "$INITIAL_PROTOCOL_VERSION"
     _step_07
-    _step_08 "$N1_PROTOCOL_VERSION"
+    _step_08 "$INITIAL_PROTOCOL_VERSION"
     _step_09
 }
 
@@ -182,6 +181,7 @@ function _step_07()
     done
 
     log "... ... awaiting new nodes to start"
+    sleep 60
     await_n_eras 1
     await_n_blocks 1
 }
@@ -212,6 +212,8 @@ function _step_08()
     N1_PROTOCOL_VERSION=$(get_node_protocol_version 1)
     if [ "$N1_PROTOCOL_VERSION" == "$N1_PROTOCOL_VERSION_INITIAL" ]; then
         log "ERROR :: protocol upgrade failure - >= protocol version did not increment"
+        log "ERROR :: Initial Proto Version: $N1_PROTOCOL_VERSION_INITIAL"
+        log "ERROR :: Current Proto Version: $N1_PROTOCOL_VERSION"
         exit 1
     fi
 
@@ -253,6 +255,7 @@ function _step_09()
 # ----------------------------------------------------------------
 
 unset _STAGE_ID
+unset INITIAL_PROTOCOL_VERSION
 
 for ARGUMENT in "$@"
 do

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -134,6 +134,8 @@ function _step_06()
     if [ "$N1_PROTOCOL_VERSION" == "$N1_PROTOCOL_VERSION_INITIAL" ]; then
         log "ERROR :: protocol upgrade failure - >= protocol version did not increment"
         exit 1
+    else
+        log "Node 1 upgraded successfully: $N1_PROTOCOL_VERSION_INITIAL -> $N1_PROTOCOL_VERSION"
     fi
 
     # Assert nodes are running same protocol version.
@@ -143,6 +145,8 @@ function _step_06()
         if [ "$NX_PROTOCOL_VERSION" != "$N1_PROTOCOL_VERSION" ]; then
             log "ERROR :: protocol upgrade failure - >= nodes are not all running same protocol version"
             exit 1
+        else
+            log "Node $NODE_ID upgraded successfully: $N1_PROTOCOL_VERSION_INITIAL -> $NX_PROTOCOL_VERSION"
         fi
     done
 }
@@ -197,7 +201,7 @@ function _step_08()
     local NX_PROTOCOL_VERSION
     local NX_STATE_ROOT_HASH
 
-    log_step 9 "asserting joined nodes are running upgrade"
+    log_step 8 "asserting joined nodes are running upgrade"
 
     # Assert all nodes are live.
     for NODE_ID in $(seq 1 "$(get_count_of_nodes)")
@@ -215,6 +219,8 @@ function _step_08()
         log "ERROR :: Initial Proto Version: $N1_PROTOCOL_VERSION_INITIAL"
         log "ERROR :: Current Proto Version: $N1_PROTOCOL_VERSION"
         exit 1
+    else
+        log "Node 1 upgraded successfully: $N1_PROTOCOL_VERSION_INITIAL -> $N1_PROTOCOL_VERSION"
     fi
 
     # Assert nodes are running same protocol version.
@@ -224,6 +230,8 @@ function _step_08()
         if [ "$NX_PROTOCOL_VERSION" != "$N1_PROTOCOL_VERSION" ]; then
             log "ERROR :: protocol upgrade failure - >= nodes are not all running same protocol version"
             exit 1
+        else
+            log "Node $NODE_ID upgraded successfully: $N1_PROTOCOL_VERSION_INITIAL -> $NX_PROTOCOL_VERSION"
         fi
     done
 

--- a/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
+++ b/utils/nctl/sh/scenarios-upgrades/upgrade_scenario_01.sh
@@ -40,8 +40,8 @@ function _main()
     _step_04
     _step_05 "$STAGE_ID"
     _step_06 "$N1_PROTOCOL_VERSION"
-    # _step_07
-    # _step_08 "$N1_PROTOCOL_VERSION"
+    _step_07
+    _step_08 "$N1_PROTOCOL_VERSION"
     _step_09
 }
 

--- a/utils/nctl/sh/staging/set_from_remote.sh
+++ b/utils/nctl/sh/staging/set_from_remote.sh
@@ -29,7 +29,14 @@ function _main()
         exit 1
     fi
 
-    PATH_TO_STAGE="$(get_path_to_stage "$STAGE_ID")/$PROTOCOL_VERSION"
+    if [ "$PROTOCOL_VERSION" = "1_1_1" ]; then
+        log "... NOTE: Setting up 1_1_1 in 1_1_0 due to known caveat."
+        PATH_TO_STAGE="$(get_path_to_stage "$STAGE_ID")/1_1_0"
+        mkdir -p "$PATH_TO_STAGE"
+        rmdir "$(get_path_to_stage "$STAGE_ID")/1_1_1"
+    else
+        PATH_TO_STAGE="$(get_path_to_stage "$STAGE_ID")/$PROTOCOL_VERSION"
+    fi
 
     cp "$PATH_TO_REMOTE"/* "$PATH_TO_STAGE"
     cp "$(get_path_to_remotes)/casper-node-launcher" "$PATH_TO_STAGE"

--- a/utils/nctl/sh/utils/queries.sh
+++ b/utils/nctl/sh/utils/queries.sh
@@ -169,7 +169,7 @@ function get_node_protocol_version_from_fs()
     local IFS='_'
 
     pushd "$PATH_TO_NODE_BIN" || exit
-    read -ra SEMVAR_CURRENT <<< "$(ls -td -- * | head -n 1)"
+    read -ra SEMVAR_CURRENT <<< "$(ls --group-directories-first -tdr -- * | head -n 1)"
     popd || exit
 
     echo "${SEMVAR_CURRENT[0]}$SEPARATOR${SEMVAR_CURRENT[1]}$SEPARATOR${SEMVAR_CURRENT[2]}"


### PR DESCRIPTION
Adds workaround for 1.1.1 ( Protocol 1.1.0)
Adds trusted hash to initial protocol config.toml for syncing nodes.
Fixes a clobbering of a variable by adding an additional variable.
Adds syncing test after final upgrade in scenario 2.
Adds assertion of upgrade to scenario 2.
Adds additional logging.
